### PR TITLE
Fix bug that shows distance of 0 when second string is one shorter than first (and otherwise identical)

### DIFF
--- a/pyxdameraulevenshtein/pyxdameraulevenshtein.pyx
+++ b/pyxdameraulevenshtein/pyxdameraulevenshtein.pyx
@@ -74,6 +74,7 @@ cpdef unsigned long damerau_levenshtein_distance(seq1, seq2):
         s1 = _to_unicode(seq1)
         s2 = _to_unicode(seq2)
 
+
     # possible short-circuit if words have a lot in common at the beginning (or are identical)
     cdef Py_ssize_t first_differing_index = 0
     while first_differing_index < len(s1) and \
@@ -88,6 +89,10 @@ cpdef unsigned long damerau_levenshtein_distance(seq1, seq2):
         return len(s2)
     if s2 is None:
         return len(s1)
+
+    # Hack to fix a bug where the second string is one shorter than the first
+    if len(s2) < len(s1):
+        s1, s2 = s2, s1
 
     # Py_ssize_t should be used wherever we're dealing with an array index or length
     cdef Py_ssize_t i, j

--- a/tests/test_pyxdl.py
+++ b/tests/test_pyxdl.py
@@ -44,6 +44,8 @@ class TestDamerauLevenshtien(unittest.TestCase):
         assert damerau_levenshtein_distance('orange', 'pumpkin') == 7
         assert damerau_levenshtein_distance('gifts', 'profit') == 5
         assert damerau_levenshtein_distance('Sjöstedt', 'Sjostedt') == 1
+        assert damerau_levenshtein_distance('tt', 't') == 1
+
         assert damerau_levenshtein_distance([1, 2, 3], [1, 3, 2]) == 1
         assert damerau_levenshtein_distance((1, 2, 3), (1, 3, 2)) == 1
         assert damerau_levenshtein_distance((1, 2, 3), [1, 3, 2]) == 1
@@ -68,6 +70,8 @@ class TestDamerauLevenshtien(unittest.TestCase):
         assert normalized_damerau_levenshtein_distance('orange', 'pumpkin') == 1.0
         assert normalized_damerau_levenshtein_distance('gifts', 'profit') == 0.8333333134651184
         assert normalized_damerau_levenshtein_distance('Sjöstedt', 'Sjostedt') == 0.125
+        assert normalized_damerau_levenshtein_distance('tt','t') == 0.5
+
         assert np.isclose(normalized_damerau_levenshtein_distance([1, 2, 3], [1, 3, 2]), 1.0 / 3.0)
         assert normalized_damerau_levenshtein_distance([], []) == 0.0
         assert np.isclose(normalized_damerau_levenshtein_distance(list(range(10)), list(range(1, 11))), 0.2)


### PR DESCRIPTION
Solves the issue in: https://github.com/gfairchild/pyxDamerauLevenshtein/issues/22

Somewhat hacky solution, swaps the variables if the second string is shorter than the first one, but works. 

Also, note, I haven't regenerated the c-file as when I did it had a lot of local path names. 